### PR TITLE
Merge Available languages endpoint back to asu-azure-dev

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -7,14 +7,14 @@ from app.database import Base, engine
 Base.metadata.create_all(engine)
 
 
-"""
-    The "Translation" Table models are used to build a single
-    translation table that is the first and main source to 
-    query for translation results.
-"""
 
 
 class UniqueTranslationsORM(Base):
+    """
+        The "unique_translation_table" model is used to build a single
+        translation table that is the first and main source to 
+        query for translation results.
+    """
     __tablename__ = "unique_translation_table"
 
     id = Column(Integer, primary_key=True)
@@ -37,7 +37,25 @@ class UniqueTranslationsORM(Base):
                 )>"
 
 
-class LanguagePairs:
-    """TODO: Define a view for language pairs from the 'unique_translation' table."""
+class LanguagePairs(Base):
+    """
+        View for language pairs from the 'unique_translation_table' table.
+        View is named: 'available_languages_view'
 
-    pass
+        Excludes odd names like  
+    """
+    __tablename__ = "available_languages_view"
+
+    source_language = Column(String, nullable=False, primary_key=True)
+    target_language = Column(String, nullable=False, primary_key=True)
+
+    __table_args__ = {'autoload_with': engine}
+    
+    def __repr__(self):
+        return f'\
+<Language(\n\
+    source_language={self.source_language},\n\
+    target_language={self.target_language}\n\
+)>'
+
+

--- a/app/routers/language.py
+++ b/app/routers/language.py
@@ -12,6 +12,32 @@ router = APIRouter(prefix="/languages", tags=["languages"])
 logger = logging.getLogger(LOGGER_NAME)
 
 
-@router.get("/", response_model=schemas.TranslationLanguageResult)
+@router.get("/", response_model=schemas.AvailableLanguages)
 def get_languages(db: Session = Depends(database.get_db)):
-    return db.query(models.LanguagePairs).all()
+    '''
+        Gets the languages currently available to translate works to
+        and from using the translate endpoint
+    '''
+    # Query to get the langauge pairs from a View in the DB
+    language_pairs = db.query(
+            models.LanguagePairs
+        ).order_by(
+            models.LanguagePairs.source_language.asc()
+        ).all()
+    
+    # Covert to pydantic models
+    avialable_languages = [
+        schemas.AvailableLanguageResult(
+            source_language=language.source_language,
+            target_language=language.target_language,
+        )
+        for language in language_pairs
+        ]
+
+    # Log the pairs we are returning
+    logger.info(f'\nLanguage pairs:\n{language_pairs}')
+    
+    # Translate to a list based on the pydantic schemas
+    return schemas.AvailableLanguages(translations=avialable_languages)
+
+    

--- a/app/routers/language.py
+++ b/app/routers/language.py
@@ -2,8 +2,9 @@ import logging
 
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
+import test
 
-import app.database as database
+from app.database import get_db
 import app.models as models
 import app.schemas as schemas
 from app.config import LOGGER_NAME
@@ -13,7 +14,7 @@ logger = logging.getLogger(LOGGER_NAME)
 
 
 @router.get("/", response_model=schemas.AvailableLanguages)
-def get_languages(db: Session = Depends(database.get_db)):
+def get_languages(db: Session = Depends(get_db)):
     '''
         Gets the languages currently available to translate works to
         and from using the translate endpoint
@@ -22,22 +23,54 @@ def get_languages(db: Session = Depends(database.get_db)):
     language_pairs = db.query(
             models.LanguagePairs
         ).order_by(
-            models.LanguagePairs.source_language.asc()
+            models.LanguagePairs.source_language.asc(),
+            models.LanguagePairs.target_language.asc()
         ).all()
     
+    # Group Languages with list of languages they can be translated to
+    grouped_languages = {}
+    for language in language_pairs:
+        if language.source_language not in grouped_languages:
+            grouped_languages[language.source_language] = []
+        grouped_languages[language.source_language].append(language.target_language)
+
     # Covert to pydantic models
-    avialable_languages = [
+    avialable_languages_list = [
         schemas.AvailableLanguageResult(
-            source_language=language.source_language,
-            target_language=language.target_language,
+            source_language=source,
+            target_languages=targets,
         )
-        for language in language_pairs
-        ]
+        for source, targets in grouped_languages.items()
+    ]
 
     # Log the pairs we are returning
     logger.info(f'\nLanguage pairs:\n{language_pairs}')
     
     # Translate to a list based on the pydantic schemas
-    return schemas.AvailableLanguages(translations=avialable_languages)
+    return schemas.AvailableLanguages(available_languages=avialable_languages_list)
 
-    
+@router.get("/test", response_model=schemas.AvailableLanguages)
+def get_translation_test(
+    db: Session = Depends(get_db)
+):
+    logging.info(db.info)
+
+    def result(num_range):
+        
+        test_result = []
+
+        for num in range(1, num_range + 1):
+            
+            source_language = f'lang{num}'
+            target_languages = [f'lang{i}' for i in range(1, num_range + 1) if i != num]
+
+            test_result.append({
+                'source_language': source_language,
+                'target_languages': target_languages, 
+
+            })
+
+        return test_result
+
+    results = {"available_languages": result(3)}
+    return results

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -3,52 +3,50 @@ from typing import List, Optional
 from pydantic import BaseModel
 
 
-class FuzzyResult(BaseModel):
-    matching_name: str
-    matching_source: str
-    matching_uid: int
-
-
-class TranslationResult(BaseModel):
-    translated_name: str
-    translated_source: str
-    translated_uid: int
-
-
-# 3 in the diagram
-class FuzzyMatching(BaseModel):
-    results: List[FuzzyResult]
-
-
 # 2 in the diagram
 class FuzzyQuery(BaseModel):
     source_language: str
     query: str
     threshold: int = 10
     nb_max_results: int = 10
+class FuzzyResult(BaseModel):
+    matching_name: str
+    matching_source: str
+    matching_uid: int
 
+# 3 in the diagram
+class FuzzyMatching(BaseModel):
+    results: List[FuzzyResult]
 
-class TranslationLanguagePair(BaseModel):
-    source_language: str
-    target_language: str
-
-    class Config:
-        from_attributes = True
-
-
-class TranslationLanguageResult(BaseModel):
-    translations: List[TranslationLanguagePair]
-
-
-# 6 in the diagram
-class Translation(BaseModel):
-    results: List[TranslationResult]
 
 
 # 5 in the diagram
 class TranslationQuery(BaseModel):
     translation_query: FuzzyResult
     target_language: str
+
+class TranslationResult(BaseModel):
+    translated_name: str
+    translated_source: str
+    translated_uid: int
+
+# 6 in the diagram
+class Translation(BaseModel):
+    results: List[TranslationResult]
+
+
+
+class AvailableLanguageResult(BaseModel):
+    source_language: str
+    target_language: str
+
+    class Config:
+        from_attributes = True
+
+class AvailableLanguages(BaseModel):
+    translations: List[AvailableLanguageResult]
+
+
 
 
 class UniqueTranslationsPYD(BaseModel):

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -38,13 +38,13 @@ class Translation(BaseModel):
 
 class AvailableLanguageResult(BaseModel):
     source_language: str
-    target_language: str
+    target_languages: list[str]
 
     class Config:
         from_attributes = True
 
 class AvailableLanguages(BaseModel):
-    translations: List[AvailableLanguageResult]
+    available_languages: List[AvailableLanguageResult]
 
 
 


### PR DESCRIPTION
Added new View to the PostgreSQL Database on Azure called 'available_languages_view' to store language pairs that words can be translated from and to.

Added SQLAlchemy model for querying the available languages view.

Renamed Pydantic 'TranslationLanguagePair' schemas to 'AvailableLanguage*' schemas. Also, reorganized the schemas to group those that are used together next to each other in the file.

Defined function for the `/languages' endpoint to query the available languages from the PostgreSQL DB and return a list of source languages with a list of languages that source can translate into.

### Demo Response: `/languages/test`

 ```
{
  "available_languages": [
    {
      "source_language": "lang1",
      "target_languages": [
        "lang2",
        "lang3"
      ]
    },
    {
      "source_language": "lang2",
      "target_languages": [
        "lang1",
        "lang3"
      ]
    },
    {
      "source_language": "lang3",
      "target_languages": [
        "lang1",
        "lang2"
      ]
    }
  ]
}
```

### Demo Response: `/languages/`

 ```
{
  "available_languages": [
    {
      "source_language": "en",
      "target_languages": [
        "ru",
        "uk"
      ]
    },
    {
      "source_language": "ru",
      "target_languages": [
        "en"
      ]
    },
    {
      "source_language": "uk",
      "target_languages": [
        "en"
      ]
    }
  ]
}
```