### PR TITLE
Rename variable table_name to source_table_name for consistency

### DIFF
--- a/app/algorithms/dbquery_medications.py
+++ b/app/algorithms/dbquery_medications.py
@@ -65,7 +65,7 @@ def dbquery_medications(
                 SELECT 
                 id AS matching_uid,
                 source_text AS matching_name, 
-                table_name AS matching_source,
+                source_table_name AS matching_source,
                 ROW_NUMBER() OVER (ORDER BY levenshtein(lower(source_text), lower(:query))) AS row_number,
                 levenshtein(lower(source_text), lower(:query)) AS distance
                 FROM unique_translation_table
@@ -80,7 +80,7 @@ def dbquery_medications(
                 """
                 WITH matched_rows AS (SELECT id,
                                              source_text,
-                                             table_name,
+                                             source_table_name,
                                              array_dms_diff(
                                                      my_daitch_mokotoff(source_text),
                                                      my_daitch_mokotoff(:query)) AS distance
@@ -89,7 +89,7 @@ def dbquery_medications(
                                         AND my_daitch_mokotoff(source_text) && my_daitch_mokotoff(:query))
                 SELECT id                                    AS matching_uid,
                        source_text                           AS matching_name,
-                       table_name                            AS matching_source,
+                       source_table_name                            AS matching_source,
                        ROW_NUMBER() OVER (ORDER BY distance) AS row_number,
                        distance
                 FROM matched_rows

--- a/app/algorithms/dms_diff.sql
+++ b/app/algorithms/dms_diff.sql
@@ -110,14 +110,14 @@ SELECT my_daitch_mokotoff('макрогол') AS dm_result_cyrillic;
 
 -- If the function works, run the original query again
 WITH matched_rows AS (SELECT source_text,
-                             table_name,
+                             source_table_name,
                              array_dms_diff(my_daitch_mokotoff(source_text), my_daitch_mokotoff('макрогол')) AS distance
                       FROM unique_translation_table
                       WHERE source_language = 'uk'
                         AND (my_daitch_mokotoff(source_text) && my_daitch_mokotoff('макрогол')))
 SELECT 0                                     AS matching_uid,
        source_text                           AS matching_name,
-       table_name                            AS matching_source,
+       source_table_name                            AS matching_source,
        ROW_NUMBER() OVER (ORDER BY distance) AS row_number,
        distance
 FROM matched_rows

--- a/app/models.py
+++ b/app/models.py
@@ -29,7 +29,7 @@ class UniqueTranslations(Base):
     target_language = Column(String, nullable=False)
     source_text = Column(String, nullable=False)
     target_text = Column(String, nullable=False)
-    table_name = Column(String, nullable=False)
+    source_table_name = Column(String, nullable=False)
     source_comment = Column(String, nullable=True)
     weight = Column(Integer, nullable=True)
     id = Column(Integer, primary_key=True, nullable=False, autoincrement=True)
@@ -48,7 +48,7 @@ class UniqueTranslations(Base):
             f"target_language={self.target_language}, "
             f"source_text={self.source_text}, "
             f"target_text={self.target_text}, "
-            f"table_name={self.table_name}, "
+            f"source_table_name={self.source_table_name}, "
             f"weight={self.weight},"
             f"description={self.description}\n"
             f")>"


### PR DESCRIPTION
Standardize the variable name across the codebase to improve clarity and maintainability.